### PR TITLE
11.21 README update: Fibers not compatible with Node 16 ->

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ https://pacific-refuge-24583.herokuapp.com/
 
 Used create-app as a test project for the exercise
 
+Note: Create-App uses Fibers which is not compatible with Node 16.0.0 ->. Needed to uninstall it. More: https://github.com/laverdet/node-fibers
+
 # create-app
 Simple boilerplate
 


### PR DESCRIPTION
Updated README.

Fibers is not compatible with Node versions 16.0.0 and later. Could not deploy app to Heroku before uninstalling Fibers. Error message: "Assertion `thread_id_key != 0x7777' failed."